### PR TITLE
Add nginx front-end to deployment

### DIFF
--- a/MENTALIA_SERVER_DEPLOY/Dockerfile
+++ b/MENTALIA_SERVER_DEPLOY/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /opt/mentalia
+
+COPY . /opt/mentalia
+
+RUN pip install --upgrade pip && \
+    pip install llama-cpp-python flask gunicorn
+
+CMD ["gunicorn", "app:app", "-b", "0.0.0.0:5000"]

--- a/MENTALIA_SERVER_DEPLOY/README_DEPLOY.md
+++ b/MENTALIA_SERVER_DEPLOY/README_DEPLOY.md
@@ -1,0 +1,19 @@
+# Despliegue Mentalia Server
+
+## Requisitos
+- Docker y docker-compose instalados
+- Puerto 80 disponible (la API se sirve internamente en el puerto 5000)
+
+## Uso
+1. Clona este entorno al servidor
+2. Coloca los archivos de Mentalia en esta carpeta
+3. Ejecuta:
+
+```bash
+chmod +x start_all.sh
+./start_all.sh
+```
+
+4. Accede a:
+- `http://<ip-servidor>/` para dashboard
+- `http://<ip-servidor>/api/chat` para API mentalia

--- a/MENTALIA_SERVER_DEPLOY/docker-compose.yml
+++ b/MENTALIA_SERVER_DEPLOY/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  mentalia:
+    build: .
+    expose:
+      - "5000"
+    volumes:
+      - .:/opt/mentalia
+    restart: always
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - .:/opt/mentalia:ro
+    depends_on:
+      - mentalia
+    restart: always

--- a/MENTALIA_SERVER_DEPLOY/nginx.conf
+++ b/MENTALIA_SERVER_DEPLOY/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name _;
+
+    location /api/ {
+        proxy_pass http://mentalia:5000/;
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        root /opt/mentalia/dashboard;
+        index index.html;
+    }
+}

--- a/MENTALIA_SERVER_DEPLOY/start_all.sh
+++ b/MENTALIA_SERVER_DEPLOY/start_all.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose up --build -d


### PR DESCRIPTION
## Summary
- include deployment folder with docker-compose, nginx config and README
- use nginx container on port 80 that proxies to the `mentalia` service
- document that only port 80 is required; API runs internally on port 5000

## Testing
- `docker-compose` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c66991aec8329ae1970ebb81f0815