### PR TITLE
Add ChileCompra scraper module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+CMD ["python", "-m", "backend.app"]

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -1,0 +1,50 @@
+# ChileCompra Scraper
+
+Este m\u00f3dulo permite consultar autom\u00e1ticamente licitaciones del portal [mercadopublico.cl](https://www.mercadopublico.cl) mediante una peque\u00f1a API en Flask.
+
+## Uso con Docker
+
+1. Defina la variable de entorno `CHILECOMPRA_API_KEY` con el ticket de acceso provisto por ChileCompra.
+2. Construya la imagen y levante el servicio:
+
+```bash
+docker-compose up --build
+```
+
+El contenedor expone el puerto `8000`.
+
+### Endpoint `/api/chilecompra`
+
+Realice peticiones GET con los siguientes par\u00e1metros opcionales:
+
+- `keywords`: palabras separadas por comas para filtrar por nombre o descripci\u00f3n.
+- `fecha_desde`: fecha inicial `YYYY-MM-DD`.
+- `fecha_hasta`: fecha final `YYYY-MM-DD`.
+- `estado`: estado de la licitaci\u00f3n (ej. `publicada` o `cerrada`).
+- `pagina`: n\u00famero de p\u00e1gina seg\u00fan la API.
+- `save`: si vale `true`, guarda los resultados en `chilecompra_results.json`.
+- `file`: nombre del archivo donde guardar (opcional).
+
+Ejemplo:
+
+```
+http://localhost:8000/api/chilecompra?keywords=inteligencia+artificial,salud+mental&estado=publicada&save=true
+```
+
+El resultado es un JSON con el listado de licitaciones encontradas.
+
+## Ejecuci\u00f3n local sin Docker
+
+Instale dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+Luego ejecute:
+
+```bash
+python -m backend.app
+```
+
+El servidor qued\u00f3 disponible en `http://localhost:8000`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,40 @@
+from flask import Flask, request, jsonify
+from .chilecompra_scraper import buscar_licitaciones, guardar_resultados
+import os
+
+app = Flask(__name__)
+
+
+@app.route("/api/chilecompra", methods=["GET"])
+def chilecompra_endpoint():
+    keywords_param = request.args.get("keywords")
+    keywords = [k.strip() for k in keywords_param.split(",") if k.strip()] if keywords_param else None
+
+    fecha_desde = request.args.get("fecha_desde")
+    fecha_hasta = request.args.get("fecha_hasta")
+    estado = request.args.get("estado")
+    pagina = int(request.args.get("pagina", 1))
+
+    api_key = os.getenv("CHILECOMPRA_API_KEY")
+
+    try:
+        licitaciones = buscar_licitaciones(
+            keywords=keywords,
+            fecha_desde=fecha_desde,
+            fecha_hasta=fecha_hasta,
+            estado=estado,
+            api_key=api_key,
+            pagina=pagina,
+        )
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    if request.args.get("save") == "true":
+        ruta = request.args.get("file", "chilecompra_results.json")
+        guardar_resultados(ruta, licitaciones)
+
+    return jsonify({"results": licitaciones})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/backend/chilecompra_scraper.py
+++ b/backend/chilecompra_scraper.py
@@ -1,0 +1,71 @@
+import os
+import json
+import requests
+from typing import List, Optional
+
+CHILECOMPRA_API_URL = "https://api.mercadopublico.cl/servicios/v1/publico/licitaciones.json"
+
+
+def buscar_licitaciones(
+    keywords: Optional[List[str]] = None,
+    fecha_desde: Optional[str] = None,
+    fecha_hasta: Optional[str] = None,
+    estado: Optional[str] = None,
+    api_key: Optional[str] = None,
+    pagina: int = 1,
+) -> List[dict]:
+    """Consulta licitaciones desde la API de ChileCompra.
+
+    Parameters
+    ----------
+    keywords : list[str], optional
+        Palabras clave para filtrar por nombre o descripci\u00f3n.
+    fecha_desde : str, optional
+        Fecha de publicaci\u00f3n inicial en formato YYYY-MM-DD.
+    fecha_hasta : str, optional
+        Fecha de publicaci\u00f3n final en formato YYYY-MM-DD.
+    estado : str, optional
+        Estado de la licitaci\u00f3n ("publicada", "cerrada", etc).
+    api_key : str, optional
+        Ticket de autenticaci\u00f3n de la API.
+    pagina : int
+        N\u00famero de p\u00e1gina a consultar.
+
+    Returns
+    -------
+    list[dict]
+        Listado de licitaciones filtradas.
+    """
+
+    params = {"pagina": pagina}
+    if api_key:
+        params["ticket"] = api_key
+    if estado:
+        params["estado"] = estado
+    if fecha_desde:
+        params["fecha"] = fecha_desde
+    if fecha_hasta:
+        params["fechaHasta"] = fecha_hasta
+
+    response = requests.get(CHILECOMPRA_API_URL, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    licitaciones = data.get("Listado", [])
+
+    if keywords:
+        lowered = [k.lower() for k in keywords]
+        filtered = []
+        for lic in licitaciones:
+            texto = f"{lic.get('Nombre', '')} {lic.get('Descripcion', '')}".lower()
+            if any(k in texto for k in lowered):
+                filtered.append(lic)
+        licitaciones = filtered
+
+    return licitaciones
+
+
+def guardar_resultados(ruta: str, data: List[dict]) -> None:
+    """Guarda resultados en archivo JSON."""
+    with open(ruta, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  app:
+    build: .
+    environment:
+      - CHILECOMPRA_API_KEY=${CHILECOMPRA_API_KEY}
+    ports:
+      - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests


### PR DESCRIPTION
## Summary
- introduce a minimal Flask backend
- implement `chilecompra_scraper` for fetching public tenders from ChileCompra
- provide Dockerfile and docker-compose setup
- document usage in new `README_DEPLOY.md`

## Testing
- `python -m py_compile backend/chilecompra_scraper.py backend/app.py`
- `python -m backend.app` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c6a9223788329a1beece52180dfa5