### PR TITLE
docs: add DevOps guide and update docs index

### DIFF
--- a/docs/DEVOPS_README.md
+++ b/docs/DEVOPS_README.md
@@ -1,0 +1,43 @@
+# 🐳 DevOps y Deployment - MENTALIA Enterprise
+
+## 🏗️ Visión General
+Este documento describe la infraestructura técnica utilizada para ejecutar el ecosistema **MENTALIA**. Incluye contenedores, configuración de servicios y automatización para despliegues locales y en la nube.
+
+## 📦 Contenedores y Servicios
+- **Dockerfile** (`./Dockerfile`): Imagen base Python 3.11 con instalación de dependencias y ejecución mediante Gunicorn.
+- **docker-compose.yml** (`./docker-compose.yml`): Orquesta el servicio principal `app` y expone el puerto `8000`.
+
+```bash
+# Construir e iniciar en segundo plano
+docker compose up -d --build
+
+# Ver logs
+docker compose logs -f
+```
+
+## 🚀 Scripts de Inicio
+- `MENTALIA-ENTERPRISE/start.sh` – inicialización de servicios completos.
+- Otros scripts de despliegue se encuentran en subdirectorios como `MENTALIA_CONSOLIDADO/infrastructure/enterprise/start.sh`.
+
+## 🔌 Puertos Principales
+- **8000** – API y documentación interactiva (`/docs`).
+- **3000** – Dashboard de monitoreo.
+- **8005** – Portal web unificado.
+
+## 🛠️ Monitoreo y Almacenamiento
+- **Grafana** – Métricas y observabilidad.
+- **MinIO** – Almacenamiento de objetos.
+- **GitHub Actions** – Integración continua y despliegue automático.
+
+## 🌐 Entornos de Ejecución
+- **GitHub Codespaces** – Entorno recomendado para desarrollo rápido.
+- **Despliegue local** – Utilizando Docker Compose y scripts de inicio.
+- **RunPod/AWS** – Objetivo para despliegues de producción.
+
+## 📈 Roadmap DevOps
+- [ ] Añadir servicios de monitoreo adicionales (Prometheus).
+- [ ] Automatizar backups en MinIO.
+- [ ] Integrar despliegue continuo hacia RunPod/AWS.
+
+---
+**Última actualización:** Agosto 2025

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Esta carpeta contiene la documentación técnica completa y organizada del ecosi
 | **[🏥 APLICACIONES_README.md](./APLICACIONES_README.md)** | 7 Aplicaciones enterprise | Product Managers, Clientes |
 | **[🔮 ORACULO_README.md](./ORACULO_README.md)** | Sistema coordinación central | Arquitectos, DevOps |
 | **[⚖️ LEGAL_README.md](./LEGAL_README.md)** | Integración ChileCompra/MINSAL | Legal, Compliance |
+| **[🐳 DEVOPS_README.md](./DEVOPS_README.md)** | Infraestructura y deployment | DevOps, Arquitectos |
 
 ### 🎭 Por Audiencia
 
@@ -45,6 +46,10 @@ Esta carpeta contiene la documentación técnica completa y organizada del ecosi
 - **[Agentes Empresariales](./AGENTES_README.md#💼-categoría-4-empresarial-20-agentes)** - 20 agentes de negocio
 - **[ROI](../README.md#📊-métricas-de-impacto)** - Retorno de inversión
 
+#### 🛠️ **Para DevOps**
+- **[Infraestructura](./DEVOPS_README.md)** - Docker, scripts y CI/CD
+- **[Monitoring](#)** - Observabilidad *(próximamente)*
+
 ## 🔄 Estado de Documentación
 
 ### ✅ **Completado**
@@ -53,9 +58,9 @@ Esta carpeta contiene la documentación técnica completa y organizada del ecosi
 - ✅ Aplicaciones - 7 apps enterprise documentadas
 - ✅ Sistema Oráculo - Coordinación central
 - ✅ Integración Legal - ChileCompra + MINSAL
+- ✅ DevOps - Infraestructura y deployment
 
 ### 🔄 **En Desarrollo**
-- 🔄 DevOps README - Infraestructura y deployment
 - 🔄 APIs Documentation - Documentación técnica APIs
 - 🔄 Security README - Seguridad y compliance
 - 🔄 Monitoring README - Observabilidad y métricas
@@ -97,11 +102,10 @@ grep -n "concepto" ./docs/AGENTES_README.md
 - **Sistema Oráculo:** 100% completo
 - **Integración Legal:** 100% completa
 - **APIs:** 60% documentadas
-- **DevOps:** 40% documentado
+- **DevOps:** 100% documentado
 
 ### 🎯 **Objetivos Próximos 30 días**
 - [ ] Completar documentación APIs (100%)
-- [ ] Finalizar guía DevOps (100%)
 - [ ] Añadir troubleshooting guide
 - [ ] Crear video tutoriales básicos
 


### PR DESCRIPTION
## Summary
- add missing DevOps README with deployment and monitoring details
- update documentation index to reference DevOps guide and mark it completed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0784ceea08329aacaf06cb45aa17d