### PR TITLE
Add estructura_mentalia module with tests

### DIFF
--- a/scripts/estructura_mentalia.py
+++ b/scripts/estructura_mentalia.py
@@ -1,0 +1,55 @@
+import os
+import json
+from pathlib import Path
+
+# Mapeo simbólico por SIP
+SIMBOLOS = {
+    "MULTIVERSO": "🌌",
+    "MENTALIZACION": "🧠",
+    "AGENTES": "💫",
+    "SISTEMAS": "🪐",
+    "RRI": "🛡️"
+}
+
+
+def clasificar(nombre):
+    nombre_up = nombre.upper()
+    for clave, emoji in SIMBOLOS.items():
+        if clave in nombre_up:
+            return f"{emoji} {nombre}"
+    return f"📁 {nombre}"
+
+
+def recorrer(base_path):
+    estructura = []
+    for root, dirs, files in os.walk(base_path):
+        nivel = Path(root).relative_to(base_path)
+        carpetas = [clasificar(d) for d in dirs]
+        archivos = [f for f in files]
+        estructura.append({
+            "ruta": str(nivel),
+            "carpetas": carpetas,
+            "archivos": archivos
+        })
+    return estructura
+
+
+if __name__ == "__main__":
+    base_path = Path(".")  # desde raíz del repo
+    estructura = recorrer(base_path)
+
+    # Guardar README simbólico
+    with open("README_MENTALIA_STRUCTURE.md", "w", encoding="utf-8") as f:
+        f.write("# 🌐 ESTRUCTURA MENTALIA\n\n")
+        for item in estructura:
+            f.write(f"\n## {item['ruta']}\n")
+            for c in item["carpetas"]:
+                f.write(f"- {c}\n")
+            for a in item["archivos"]:
+                f.write(f"  - 📄 {a}\n")
+
+    # Guardar JSON estructural
+    with open("estructura_universal.json", "w", encoding="utf-8") as f:
+        json.dump(estructura, f, indent=2, ensure_ascii=False)
+
+    print("✅ Estructura generada correctamente.")

--- a/tests/test_estructura_mentalia.py
+++ b/tests/test_estructura_mentalia.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import os
+from scripts.estructura_mentalia import clasificar, recorrer
+
+
+def test_clasificar_mapeo():
+    assert clasificar('multiverso') == '🌌 multiverso'
+    assert clasificar('MENTALIZACION total') == '🧠 MENTALIZACION total'
+    assert clasificar('Agentes especiales') == '💫 Agentes especiales'
+    assert clasificar('sistemas operativos') == '🪐 sistemas operativos'
+    assert clasificar('rri documentacion') == '🛡️ rri documentacion'
+
+
+def test_clasificar_default():
+    assert clasificar('otros') == '📁 otros'
+
+
+def test_recorrer(tmp_path):
+    sub = tmp_path / 'multiverso'
+    sub.mkdir()
+    (tmp_path / 'archivo.txt').write_text('hola')
+
+    estructura = recorrer(tmp_path)
+
+    root_entry = next(e for e in estructura if e['ruta'] == '.')
+    assert '🌌 multiverso' in root_entry['carpetas']
+    assert 'archivo.txt' in root_entry['archivos']
+
+    sub_entry = next(e for e in estructura if e['ruta'] == 'multiverso')
+    assert sub_entry['carpetas'] == []
+    assert sub_entry['archivos'] == []


### PR DESCRIPTION
## Summary
- add new `scripts/estructura_mentalia.py` module with helper methods
- expose module as package via `scripts/__init__.py`
- add tests for `clasificar` and `recorrer`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c669a85688329aad12bdb74a56199